### PR TITLE
Fix status message not updating after successful authentication

### DIFF
--- a/tradfri-manager.js
+++ b/tradfri-manager.js
@@ -162,6 +162,7 @@ export async function getIkeaDevices(gwkey = "undefined") {
         } else if (result && result.tradfri) {
             updateState({
                 firstRun: false,
+                authFailed: false,
                 gatewayAvailable: true,
                 gatewayDiscovered: true,
                 tradfri: result.tradfri


### PR DESCRIPTION
After successfully authenticating with the security code, the authFailed state was not being cleared in tradfri-manager.js, causing the extension UI to still display 'Authentication failed. Please re-enter security code' even though authentication succeeded.

Fixed by adding authFailed: false to the state update when connection succeeds with valid credentials.

Generated by Mistral Vibe.