### PR TITLE
fix: skip CI on merge commits to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    # Skip on merge commits to main (already ran on PR)
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, 'Merge pull request')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -30,6 +32,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: lint
+    # Skip on merge commits to main (already ran on PR)
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, 'Merge pull request')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Add conditions to skip CI workflow on merge commits to main (already ran on PR).