### PR TITLE
fix: await observeDevices to prevent hanging

### DIFF
--- a/tradfri-manager.js
+++ b/tradfri-manager.js
@@ -179,7 +179,7 @@ export async function getIkeaDevices(gwkey = "undefined") {
             }
 
             const tradfri = result.tradfri;
-            tradfri.observeDevices();
+            await tradfri.observeDevices();
             await delay(5000);
 
             const devices = [];


### PR DESCRIPTION
Fixes the issue where the extension becomes hung or stuck after reconnecting to the IKEA gateway.

The observeDevices method from node-tradfri-client returns a Promise that resolves when all devices are discovered. Previously, this was not awaited, which could cause the code to continue before device discovery completes, leading to unresolved promises that could hang the Node.js process.

By awaiting the promise, we ensure proper sequencing and prevent the process from hanging.