### PR TITLE
fix: improve status messages during device scanning and reconnection

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,8 +1,11 @@
 name: Build and Push Docker Image
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches: [main]
+    types:
+      - completed
   release:
     types: [ published ]
 
@@ -10,6 +13,8 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    # Only run if the triggering workflow (CI) succeeded
+    if: ${{ github.event_name == 'release' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -26,7 +31,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Get latest release version
-        if: github.event_name == 'release' || github.event_name == 'push'
+        if: github.event_name == 'release' || github.event_name == 'workflow_run'
         id: get-latest-release
         run: |
           # Get the latest release tag
@@ -40,8 +45,8 @@ jobs:
             echo "release_version=${VERSION}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Set test version and update files (for push to main)
-        if: github.event_name == 'push'
+      - name: Set test version and update files (for workflow_run to main)
+        if: github.event_name == 'workflow_run'
         id: set-test-version
         run: |
           # Use latest release version with -test suffix
@@ -74,7 +79,7 @@ jobs:
           node -e "const fs = require('fs'); let reg = fs.readFileSync('.reg/settings', 'utf8'); reg = reg.replace(/^VERSION=.*/m, 'VERSION=${VERSION}'); fs.writeFileSync('.reg/settings', reg);"
 
       - name: Build and push (main branch)
-        if: github.event_name == 'push'
+        if: github.event_name == 'workflow_run'
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/app.js
+++ b/app.js
@@ -104,12 +104,21 @@ const roon = new RoonApi({
     },
 
     core_unpaired: async function(core) {
-        logger.info(`${core.core_id}, ${core.display_name}, ${core.display_version}, - LOST`);
-        // Cleanup resources when core is unpaired
-        stopGatewayMonitor();
-        await cleanupTradfriConnection();
-        // Restart gateway monitor to allow reconnection when core comes back
-        setTimeout(startGatewayMonitor, 5000);
+        try {
+            logger.info(`${core.core_id}, ${core.display_name}, ${core.display_version}, - LOST`);
+            // Cleanup resources when core is unpaired
+            stopGatewayMonitor();
+            await cleanupTradfriConnection();
+            // Restart gateway monitor to allow reconnection when core comes back
+            setTimeout(startGatewayMonitor, 5000);
+            // Restart Roon discovery to find the core again
+            setTimeout(() => {
+                logger.info('Restarting Roon discovery after core loss...');
+                roon.start_discovery();
+            }, 6000);
+        } catch (err) {
+            logger.error('Error in core_unpaired callback:', err && err.message ? err.message : err);
+        }
     }
 });
 
@@ -149,7 +158,7 @@ updateStatus(svc_status);
 
 // Global error handlers
 process.on('uncaughtException', (err) => {
-    logger.error('Uncaught Exception:', err && err.message ? err.message : err);
+    logger.error('Uncaught Exception:', err && err.message ? err.message : err, err && err.stack ? '\n' + err.stack : '');
     // Try to recover by resetting state
     stopGatewayMonitor();
     setStateValue('gatewayDiscovering', false);
@@ -158,6 +167,11 @@ process.on('uncaughtException', (err) => {
     }).finally(() => {
         // Restart gateway monitor after cleanup to allow reconnection
         setTimeout(startGatewayMonitor, 5000);
+        // Also try to restart Roon discovery to reconnect to core
+        setTimeout(() => {
+            logger.info('Restarting Roon discovery after error...');
+            roon.start_discovery();
+        }, 6000);
     });
 });
 
@@ -172,7 +186,8 @@ roon.start_discovery();
 
 // Start Tradfri discovery in parallel - it will auto-retry on failure
 const mysettings = getSettings();
-// Update status to show scanning message before starting discovery
+// Set discovering state before starting discovery so status shows "Scanning..."
+setStateValue('gatewayDiscovering', true);
 updateStatus(svc_status);
 getIkeaDevices(mysettings.ikeagwkey).then(() => {
     updateStatus(svc_status);

--- a/settings-manager.js
+++ b/settings-manager.js
@@ -225,7 +225,9 @@ export function createSettingsService(roon, svc_status) {
                     updateStateSettings({ ikeagwkey: gwkey });
 
                     try {
-                        // Show scanning status before starting discovery
+                        // Set discovering state before starting discovery so status shows "Scanning..."
+                        setStateValue('gatewayDiscovering', true);
+                        // Update status to show scanning message
                         if (statusService) {
                             updateStatus(statusService);
                         }

--- a/tradfri-manager.js
+++ b/tradfri-manager.js
@@ -46,7 +46,8 @@ export function startGatewayMonitor() {
 
         try {
             // If we already have a connection, nothing to check
-            if (getStateValue('gatewayAvailable') && getStateValue('tradfri')) {
+            const tradfri = getStateValue('tradfri');
+            if (getStateValue('gatewayAvailable') && tradfri) {
                 return;
             }
 
@@ -54,14 +55,24 @@ export function startGatewayMonitor() {
             if (getStateValue('gatewayDiscovered')) {
                 logger.info("Attempting to reconnect to previously discovered gateway...");
                 setStateValue('ikeaDevices', []);
+                setStateValue('gatewayDiscovering', true);
                 const mysettings = getSettings();
-                await getIkeaDevices(mysettings.ikeagwkey);
+                try {
+                    await getIkeaDevices(mysettings.ikeagwkey);
+                } finally {
+                    setStateValue('gatewayDiscovering', false);
+                }
                 return;
             }
 
             // Gateway not yet discovered - start discovery
             logger.info("Starting gateway discovery...");
-            await getIkeaDevices();
+            setStateValue('gatewayDiscovering', true);
+            try {
+                await getIkeaDevices();
+            } finally {
+                setStateValue('gatewayDiscovering', false);
+            }
         } catch (err) {
             logger.info("IKEA gateway check failed:", err && err.message ? err.message : err);
             updateState({


### PR DESCRIPTION
## Changes

1. **Status message improvement**: Set  state before starting discovery so the status shows 'Scanning for IKEA devices...' instead of 'Input security code' during device discovery.

2. **Reconnection fix**: Restart Roon discovery after core loss or uncaught exception to properly reconnect. Added error handling to  callback to prevent crashes.

3. **Docker workflow**: Updated to trigger only after CI workflow succeeds using  event, preventing builds on failed commits.

## Testing
- All existing tests pass
- Linting passes
- Manual testing shows improved status messages and better reconnection behavior

## Files changed
- : Added Roon discovery restart on errors, improved error logging with stack traces
- : Set discovering state before device discovery
- : Properly manage gatewayDiscovering state with try-finally blocks
- : Trigger on CI success using workflow_run event