### PR TITLE
fix: await async turnOn/turnOff calls and add error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,10 +70,14 @@ const roon = new RoonApi({
                             if (output.output_id === getStateValue('outputId')) {
                                 if (zone.state === "playing" || zone.state === "loading") {
                                     logger.info('Turning ON IKEA device');
-                                    turnIkeaDevice("ON", getSettings().ikeaplug);
+                                    turnIkeaDevice("ON", getSettings().ikeaplug).catch(err => {
+                                        logger.error('Failed to turn ON IKEA device:', err.message);
+                                    });
                                 } else {
                                     logger.info('Turning OFF IKEA device');
-                                    turnIkeaDevice("OFF", getSettings().ikeaplug);
+                                    turnIkeaDevice("OFF", getSettings().ikeaplug).catch(err => {
+                                        logger.error('Failed to turn OFF IKEA device:', err.message);
+                                    });
                                 }
                             }
                         });

--- a/tradfri-manager.js
+++ b/tradfri-manager.js
@@ -227,25 +227,38 @@ export async function getIkeaDevices(gwkey = "undefined") {
  * Turn an IKEA device on or off
  * @param {string} cmd - "ON" or "OFF"
  * @param {string} deviceid - Device ID
+ * @returns {Promise<boolean>} - true if successful, false if failed
  */
 export async function turnIkeaDevice(cmd, deviceid) {
     const tradfri = getStateValue('tradfri');
     if (!tradfri || !tradfri.devices) {
-        logger.info("Cannot turn device - tradfri not connected");
-        return;
+        logger.warn("Cannot turn device - tradfri not connected");
+        return false;
     }
 
-    for (const deviceId in tradfri.devices) {
-        if (deviceId === deviceid) {
-            const device = tradfri.devices[deviceId];
-            const accessory = device.plugList[0];
-            accessory.client = tradfri;
-            if (cmd === "ON") {
-                accessory.turnOn();
-            } else if (cmd === "OFF") {
-                accessory.turnOff();
+    try {
+        for (const deviceId in tradfri.devices) {
+            if (deviceId === deviceid) {
+                const device = tradfri.devices[deviceId];
+                const accessory = device.plugList[0];
+                accessory.client = tradfri;
+                
+                if (cmd === "ON") {
+                    await accessory.turnOn();
+                    logger.info(`Successfully turned ON device ${deviceid}`);
+                    return true;
+                } else if (cmd === "OFF") {
+                    await accessory.turnOff();
+                    logger.info(`Successfully turned OFF device ${deviceid}`);
+                    return true;
+                }
             }
         }
+        logger.warn(`Device ${deviceid} not found in tradfri devices`);
+        return false;
+    } catch (err) {
+        logger.error(`Error turning device ${deviceid} ${cmd}:`, err.message);
+        return false;
     }
 }
 


### PR DESCRIPTION
## Problem
The IKEA Tradfri switch was intermittently failing to turn on/off when Roon zones started/stopped playing.

## Root Cause
The `turnIkeaDevice()` function in `tradfri-manager.js` was calling `accessory.turnOn()` and `accessory.turnOff()` **without awaiting** the returned Promises. The node-tradfri-client library confirms these methods return `Promise<boolean>`, but the Promises were being created and immediately abandoned.

**Evidence from Kubernetes logs:**
- Many "Turning ON IKEA device" messages without corresponding success confirmations
- "Unhandled Rejection at:" warnings appearing frequently
- No error messages from node-tradfri-client (because Promise rejections were silently swallowed)

## Solution
1. **Fixed `turnIkeaDevice()` in `tradfri-manager.js`:**
   - Added `await` before `accessory.turnOn()` and `accessory.turnOff()` calls
   - Wrapped device control logic in try-catch block with proper error logging
   - Added success/failure logging messages
   - Function now returns `Promise<boolean>` to indicate success/failure

2. **Added error handling in `app.js` zone callback:**
   - Added `.catch()` handlers to both `turnIkeaDevice` calls
   - Errors are now properly logged at the call site

## Changes Made
- `tradfri-manager.js`: Updated `turnIkeaDevice()` function to properly await async calls and handle errors
- `app.js`: Added `.catch()` handlers to device control calls in zone subscription callback

## Testing
- All 34 existing tests pass
- New logging messages confirmed in test output

## Expected Impact
After deployment:
- ✅ Switches should turn on/off reliably
- ✅ "Successfully turned ON/OFF device <id>" messages will appear in logs
- ✅ "Failed to turn ON/OFF IKEA device: <error>" on failures (with actual error details)
- ❌ "Unhandled Rejection at:" warnings should be gone

Fixes #N/A (no existing issue, but resolves intermittent switch control failures reported by user)

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>